### PR TITLE
[refactor] Remove UnsignedEvent type

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -131,7 +131,6 @@ jobs:
 
       - name: Start Tilt
         run: |
-          minikube addons enable ingress
           tilt up --stream -f relay/deploy/Tiltfile > /tmp/server.log 2>&1 &
 
       - name: Wait for Traefik to come up

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,7 @@ import ssl
 import pytest
 import websockets
 
+from ndk import crypto
 from ndk.relay import (
     event_handler,
     message_dispatcher,
@@ -50,6 +51,11 @@ def pytest_addoption(parser):
         default=None,
         help="The URL of the relay server to test",
     )
+
+
+@pytest.fixture
+def keys():
+    return crypto.KeyPair()
 
 
 @pytest.fixture(scope="session")

--- a/ndk/event/contact_list_event.py
+++ b/ndk/event/contact_list_event.py
@@ -22,21 +22,26 @@
 import dataclasses
 import typing
 
-from ndk import crypto
+from ndk import crypto, types
 from ndk.event import event, event_tags
 from ndk.repos import contacts
 
 
 @dataclasses.dataclass
-class ContactListEvent(event.UnsignedEvent):
+class ContactListEvent(event.SignedEvent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def from_contact_list(
-        cls, contact_list: typing.Optional[typing.Iterable[contacts.ContactInfo]] = None
+        cls,
+        keys: crypto.KeyPair,
+        contact_list: typing.Optional[typing.Iterable[contacts.ContactInfo]] = None,
     ) -> "ContactListEvent":
         tags = event_tags.EventTags([])
         if contact_list:
             tags = event_tags.EventTags([ci.to_event_tag() for ci in contact_list])
-        return cls(kind=event.EventKind.CONTACT_LIST, tags=tags)
+        return cls.build(keys=keys, kind=types.EventKind.CONTACT_LIST, tags=tags)
 
     def get_contact_list(self) -> contacts.ContactList:
         return contacts.ContactList(

--- a/ndk/event/event_builder.py
+++ b/ndk/event/event_builder.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import typing
+
+from ndk import crypto, types
+from ndk.event import (
+    contact_list_event,
+    event,
+    event_tags,
+    metadata_event,
+    reaction_event,
+    recommend_server_event,
+    repost_event,
+    text_note_event,
+)
+
+LOOKUP: dict[types.EventKind, typing.Type[event.SignedEvent]] = {
+    types.EventKind.SET_METADATA: metadata_event.MetadataEvent,
+    types.EventKind.RECOMMEND_SERVER: recommend_server_event.RecommendServerEvent,
+    types.EventKind.TEXT_NOTE: text_note_event.TextNoteEvent,
+    types.EventKind.CONTACT_LIST: contact_list_event.ContactListEvent,
+    types.EventKind.REPOST: repost_event.RepostEvent,
+    types.EventKind.REACTION: reaction_event.ReactionEvent,
+}
+
+REQUIRED_FIELDS = set(["id", "pubkey", "created_at", "kind", "tags", "content", "sig"])
+
+
+def from_dict(fields: dict, skip_validate=False):
+    actual = set(fields.keys())
+    if not REQUIRED_FIELDS == actual:
+        raise ValueError(
+            f"Required attributes not provided: {REQUIRED_FIELDS} != {actual}"
+        )
+
+    if fields["kind"] not in LOOKUP:
+        raise ValueError(f"Unknown event kind: {fields['kind']}")
+
+    return LOOKUP[fields["kind"]](
+        id=types.EventID(fields["id"]),
+        pubkey=crypto.PublicKeyStr(fields["pubkey"]),
+        created_at=fields["created_at"],
+        kind=types.EventKind(fields["kind"]),
+        tags=event_tags.EventTags(fields["tags"]),
+        content=fields["content"],
+        sig=crypto.SchnorrSigStr(fields["sig"]),
+        skip_validate=skip_validate,
+    )
+
+
+def from_validated_dict(fields: dict):
+    return LOOKUP[fields["kind"]](**fields, skip_validate=True)

--- a/ndk/event/event_filter.py
+++ b/ndk/event/event_filter.py
@@ -24,6 +24,7 @@ import dataclasses
 import logging
 import typing
 
+from ndk import types
 from ndk.event import event
 
 # "ids": <a list of event ids or prefixes>,
@@ -97,7 +98,7 @@ class EventFilter:
 
         if self.kinds is not None:
             for kind in self.kinds:
-                if kind not in event.EventKind.__members__.values():
+                if kind not in types.EventKind.__members__.values():
                     logger.warning(
                         "Creating filter %s w/ unknown event type: %s", self, kind
                     )

--- a/ndk/event/metadata_event.py
+++ b/ndk/event/metadata_event.py
@@ -22,20 +22,24 @@
 import dataclasses
 import typing
 
-from ndk import serialize
+from ndk import crypto, serialize, types
 from ndk.event import event
 
 
 @dataclasses.dataclass
-class MetadataEvent(event.UnsignedEvent):
+class MetadataEvent(event.SignedEvent):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def from_metadata_parts(
         cls,
+        keys: crypto.KeyPair,
         name: typing.Optional[str] = None,
         about: typing.Optional[str] = None,
         picture: typing.Optional[str] = None,
         **kwargs,
-    ) -> "MetadataEvent":
+    ):
         content = {**kwargs}
         if name:
             content["name"] = name
@@ -47,4 +51,6 @@ class MetadataEvent(event.UnsignedEvent):
             content["picture"] = picture
 
         serialized_content = serialize.serialize_as_str(content)
-        return cls(kind=event.EventKind.SET_METADATA, content=serialized_content)
+        return cls.build(
+            keys=keys, kind=types.EventKind.SET_METADATA, content=serialized_content
+        )

--- a/ndk/event/reaction_event.py
+++ b/ndk/event/reaction_event.py
@@ -19,14 +19,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-from ndk import exceptions
+from ndk import crypto, exceptions, types
 from ndk.event import event, event_tags
 
 
-class ReactionEvent(event.UnsignedEvent):
+class ReactionEvent(event.SignedEvent):
     @classmethod
     def from_text_note_event(
         cls,
+        keys: crypto.KeyPair,
         text_note: event.SignedEvent,
         content: str = "+",
     ) -> "ReactionEvent":
@@ -37,7 +38,9 @@ class ReactionEvent(event.UnsignedEvent):
         tags.add(event_tags.PublicKeyTag.from_pubkey(text_note.pubkey))
         tags.add(event_tags.EventIdTag.from_event_id(text_note.id))
 
-        return cls(kind=event.EventKind.REACTION, content=content, tags=tags)
+        return cls.build(
+            keys=keys, kind=types.EventKind.REACTION, content=content, tags=tags
+        )
 
     def validate(self):
         if len(self.tags) < 2:

--- a/ndk/event/recommend_server_event.py
+++ b/ndk/event/recommend_server_event.py
@@ -19,10 +19,11 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+from ndk import crypto, types
 from ndk.event import event
 
 
-class RecommendServerEvent(event.UnsignedEvent):
+class RecommendServerEvent(event.SignedEvent):
     @classmethod
-    def from_url(cls, url: str) -> "RecommendServerEvent":
-        return cls(kind=event.EventKind.RECOMMEND_SERVER, content=url)
+    def from_url(cls, keys: crypto.KeyPair, url: str) -> "RecommendServerEvent":
+        return cls.build(keys=keys, kind=types.EventKind.RECOMMEND_SERVER, content=url)

--- a/ndk/event/repost_event.py
+++ b/ndk/event/repost_event.py
@@ -19,14 +19,15 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-from ndk import exceptions
+from ndk import crypto, exceptions, types
 from ndk.event import event, event_tags
 
 
-class RepostEvent(event.UnsignedEvent):
+class RepostEvent(event.SignedEvent):
     @classmethod
     def from_text_note_event(
         cls,
+        keys: crypto.KeyPair,
         text_note: event.SignedEvent,
         relay_url: str,
         content: str = "",
@@ -35,7 +36,9 @@ class RepostEvent(event.UnsignedEvent):
         tags.add(event_tags.PublicKeyTag.from_pubkey(text_note.pubkey))
         tags.add(event_tags.EventIdTag.from_event_id(text_note.id, relay_url))
 
-        return cls(kind=event.EventKind.REPOST, content=content, tags=tags)
+        return cls.build(
+            keys=keys, kind=types.EventKind.REPOST, content=content, tags=tags
+        )
 
     def validate(self):
         if len(self.tags) not in (1, 2):

--- a/ndk/event/stored_events.py
+++ b/ndk/event/stored_events.py
@@ -21,18 +21,18 @@
 
 import typing
 
-from ndk.event import event, event_parser
+from ndk.event import event, event_builder
 from ndk.messages import eose, message, notice, relay_event
 
 
 class StoredEvents:
-    _events: list[event.UnsignedEvent]
+    _events: list[event.SignedEvent]
     _complete: bool = False
 
     def __init__(self):
         self._events = []
 
-    def get(self) -> typing.Sequence[event.UnsignedEvent]:
+    def get(self) -> typing.Sequence[event.SignedEvent]:
         assert self._complete, "cant access results before processing complete"
         return self._events
 
@@ -49,7 +49,5 @@ class StoredEvents:
         if not isinstance(msg, relay_event.RelayEvent):
             raise RuntimeError(f"Unhandled message type: {msg}")
 
-        self._events.append(
-            event_parser.signed_to_unsigned(event.SignedEvent.from_dict(msg.event_dict))
-        )
+        self._events.append(event_builder.from_dict(msg.event_dict))
         return False

--- a/ndk/event/test_event_builder.py
+++ b/ndk/event/test_event_builder.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# pylint: disable=redefined-outer-name
+
+import pytest
+
+from ndk import crypto, exceptions, types
+from ndk.event import event_builder, metadata_event
+
+
+@pytest.fixture
+def signed():
+    return metadata_event.MetadataEvent.from_metadata_parts(crypto.KeyPair())
+
+
+def test_signed_event_from_dict_bad_input():
+    with pytest.raises(ValueError):
+        event_builder.from_dict({})
+
+
+def test_signed_event_from_dict_bad_pubkey(signed):
+    base_dict = signed.__dict__
+    base_dict["pubkey"] = "badpubkey"
+
+    with pytest.raises(ValueError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_malformed_sig(signed):
+    base_dict = signed.__dict__
+    base_dict["sig"] = "badsig"
+
+    with pytest.raises(ValueError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_formed_bad_sig(signed):
+    base_dict = signed.__dict__
+    base_dict["sig"] = "a" * 128
+
+    with pytest.raises(ValueError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_malformed_id(signed):
+    base_dict = signed.__dict__
+    base_dict["id"] = "a" * 63
+
+    with pytest.raises(ValueError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_wrong_sig(signed):
+    signed2 = metadata_event.MetadataEvent.from_metadata_parts(crypto.KeyPair())
+
+    base_dict = signed.__dict__
+    base_dict["sig"] = signed2.sig
+
+    with pytest.raises(exceptions.ValidationError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_wrong_id(signed):
+    signed2 = metadata_event.MetadataEvent.from_metadata_parts(crypto.KeyPair())
+
+    base_dict = signed.__dict__
+    base_dict["id"] = signed2.id
+
+    with pytest.raises(exceptions.ValidationError):
+        event_builder.from_dict(base_dict)
+
+
+def test_signed_event_from_dict_ok(signed):
+    event_builder.from_dict(signed.__dict__)
+
+
+def test_from_dict_id_sig_mismatch(signed):
+    d = signed.__dict__
+    d["id"] = "a" * 64
+    with pytest.raises(exceptions.ValidationError):
+        event_builder.from_dict(d)
+
+
+def test_from_dict_invalid_id_errors(signed):
+    d = signed.__dict__
+    d["kind"] = types.EventKind.INVALID
+    with pytest.raises(ValueError):
+        event_builder.from_dict(d)
+
+
+def test_from_validated_dict_correct(signed):
+    signed2 = event_builder.from_validated_dict(signed.__dict__)
+    assert signed == signed2
+
+
+def test_from_validated_dict_bad_no_error(signed):
+    d = signed.__dict__
+    d["id"] = "uh oh"
+    event_builder.from_validated_dict(d)

--- a/ndk/event/test_reaction_event.py
+++ b/ndk/event/test_reaction_event.py
@@ -18,12 +18,13 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+# pylint: disable=redefined-outer-name
 # https://github.com/nostr-protocol/nips/blob/master/18.md
 
 import pytest
 
 from ndk import crypto, exceptions, types
-from ndk.event import event, event_tags, reaction_event, text_note_event
+from ndk.event import event_tags, reaction_event, text_note_event
 
 TEST_AUTHOR = crypto.PublicKeyStr(
     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
@@ -36,56 +37,63 @@ VALID_TAG_1 = ["e", TEST_EVENT_ID, TEST_RELAY_URL]
 VALID_TAG_2 = ["p", TEST_AUTHOR]
 
 
-def test_no_tags():
+def test_no_tags(keys):
     with pytest.raises(exceptions.ValidationError):
-        reaction_event.ReactionEvent(
-            kind=event.EventKind.REACTION,
+        reaction_event.ReactionEvent.build(
+            keys=keys,
+            kind=types.EventKind.REACTION,
         )
 
 
-def test_two_tags_no_p():
+def test_two_tags_no_p(keys):
     with pytest.raises(exceptions.ValidationError):
-        reaction_event.ReactionEvent(
-            kind=event.EventKind.REACTION,
+        reaction_event.ReactionEvent.build(
+            keys=keys,
+            kind=types.EventKind.REACTION,
             tags=event_tags.EventTags([VALID_TAG_1, VALID_TAG_1]),
         )
 
 
-def test_two_tags_no_e():
+def test_two_tags_no_e(keys):
     with pytest.raises(exceptions.ValidationError):
-        reaction_event.ReactionEvent(
-            kind=event.EventKind.REACTION,
+        reaction_event.ReactionEvent.build(
+            keys=keys,
+            kind=types.EventKind.REACTION,
             tags=event_tags.EventTags([VALID_TAG_2, VALID_TAG_2]),
         )
 
 
-def test_minimum_valid():
-    reaction_event.ReactionEvent(
-        kind=event.EventKind.REACTION,
+def test_minimum_valid(keys):
+    reaction_event.ReactionEvent.build(
+        keys=keys,
+        kind=types.EventKind.REACTION,
         tags=event_tags.EventTags([VALID_TAG_1, VALID_TAG_2]),
     )
 
 
-def test_no_tag_text_note():
-    keys = crypto.KeyPair()
-    unsigned_event = text_note_event.TextNoteEvent.from_content("Hello, world!")
-    signed = event.build_signed_event(unsigned_event, keys)
-
-    reaction = reaction_event.ReactionEvent.from_text_note_event(signed, content="+")
+def test_no_tag_text_note(keys):
+    signed = text_note_event.TextNoteEvent.from_content(
+        keys=keys, content="Hello, world!"
+    )
+    reaction = reaction_event.ReactionEvent.from_text_note_event(
+        keys=keys, text_note=signed, content="+"
+    )
 
     assert ["e", signed.id] in reaction.tags.get("e")
     assert ["p", signed.pubkey] in reaction.tags.get("p")
     assert reaction.content == "+"
 
 
-def test_text_note_with_e_p_tags():
-    keys = crypto.KeyPair()
-    unsigned_event = text_note_event.TextNoteEvent.from_content(
-        "Hello, world!", tags=event_tags.EventTags([VALID_TAG_1, VALID_TAG_2])
+def test_text_note_with_e_p_tags(keys):
+    signed = text_note_event.TextNoteEvent.from_content(
+        keys=keys,
+        content="Hello, world!",
+        tags=event_tags.EventTags([VALID_TAG_1, VALID_TAG_2]),
     )
-    signed = event.build_signed_event(unsigned_event, keys)
 
-    reaction = reaction_event.ReactionEvent.from_text_note_event(signed, content="+")
+    reaction = reaction_event.ReactionEvent.from_text_note_event(
+        keys=keys, text_note=signed, content="+"
+    )
 
     assert ["e", signed.id] in reaction.tags
     assert VALID_TAG_1 in reaction.tags

--- a/ndk/event/test_repost_event.py
+++ b/ndk/event/test_repost_event.py
@@ -23,7 +23,7 @@
 import pytest
 
 from ndk import crypto, exceptions, types
-from ndk.event import event, event_tags, repost_event, text_note_event
+from ndk.event import event_tags, repost_event, text_note_event
 
 TEST_AUTHOR = crypto.PublicKeyStr(
     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
@@ -37,62 +37,73 @@ VALID_TAG_1 = ["e", TEST_EVENT_ID, TEST_RELAY_URL]
 VALID_TAG_2 = ["p", TEST_AUTHOR]
 
 
-def test_basic():
-    keys = crypto.KeyPair()
-    unsigned_event = text_note_event.TextNoteEvent.from_content("Hello, world!")
-    signed = event.build_signed_event(unsigned_event, keys)
-    ev = repost_event.RepostEvent.from_text_note_event(signed, TEST_RELAY_URL)
+def test_basic(keys):
+    signed = text_note_event.TextNoteEvent.from_content(
+        keys=keys, content="Hello, world!"
+    )
+    ev = repost_event.RepostEvent.from_text_note_event(
+        keys=keys, text_note=signed, relay_url=TEST_RELAY_URL
+    )
     assert ev.content == ""
     assert ["p", signed.pubkey] in ev.tags
     assert ["e", signed.id, TEST_RELAY_URL] in ev.tags
 
 
-def test_ssl_relay():
-    keys = crypto.KeyPair()
-    unsigned_event = text_note_event.TextNoteEvent.from_content("Hello, world!")
-    signed = event.build_signed_event(unsigned_event, keys)
-    ev = repost_event.RepostEvent.from_text_note_event(signed, TEST_RELAY_URL_SSL)
+def test_ssl_relay(keys):
+    signed = text_note_event.TextNoteEvent.from_content(
+        keys=keys, content="Hello, world!"
+    )
+    ev = repost_event.RepostEvent.from_text_note_event(
+        keys=keys, text_note=signed, relay_url=TEST_RELAY_URL_SSL
+    )
     assert ev.content == ""
     assert ["p", signed.pubkey] in ev.tags
     assert ["e", signed.id, TEST_RELAY_URL_SSL] in ev.tags
 
 
-def test_no_tags():
+def test_no_tags(keys):
     with pytest.raises(exceptions.ValidationError):
-        repost_event.RepostEvent(
-            kind=event.EventKind.REPOST, tags=event_tags.EventTags([]), content=""
+        repost_event.RepostEvent.build(
+            keys=keys,
+            kind=types.EventKind.REPOST,
+            tags=event_tags.EventTags([]),
+            content="",
         )
 
 
-def test_one_tag_wrong_type():
+def test_one_tag_wrong_type(keys):
     with pytest.raises(exceptions.ValidationError):
-        repost_event.RepostEvent(
-            kind=event.EventKind.REPOST,
+        repost_event.RepostEvent.build(
+            keys=keys,
+            kind=types.EventKind.REPOST,
             tags=event_tags.EventTags([["a", "foo"]]),
             content="",
         )
 
 
-def test_two_tag_wrong_second_type():
+def test_two_tag_wrong_second_type(keys):
     with pytest.raises(exceptions.ValidationError):
-        repost_event.RepostEvent(
-            kind=event.EventKind.REPOST,
+        repost_event.RepostEvent.build(
+            keys=keys,
+            kind=types.EventKind.REPOST,
             tags=event_tags.EventTags([VALID_TAG_1, ["a", "foo"]]),
             content="",
         )
 
 
-def test_two_tag_order_1():
-    repost_event.RepostEvent(
-        kind=event.EventKind.REPOST,
+def test_two_tag_order_1(keys):
+    repost_event.RepostEvent.build(
+        keys=keys,
+        kind=types.EventKind.REPOST,
         tags=event_tags.EventTags([VALID_TAG_1, VALID_TAG_2]),
         content="",
     )
 
 
-def test_two_tag_order_2():
-    repost_event.RepostEvent(
-        kind=event.EventKind.REPOST,
+def test_two_tag_order_2(keys):
+    repost_event.RepostEvent.build(
+        keys=keys,
+        kind=types.EventKind.REPOST,
         tags=event_tags.EventTags([VALID_TAG_2, VALID_TAG_1]),
         content="",
     )

--- a/ndk/event/test_text_note_event.py
+++ b/ndk/event/test_text_note_event.py
@@ -19,22 +19,23 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-from ndk.event import event, event_tags, text_note_event
+from ndk import types
+from ndk.event import event_tags, text_note_event
 
 VALID_PUBKEY_STR = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
 
 
-def test_from_content_no_tags():
-    ev = text_note_event.TextNoteEvent.from_content("Hello World!")
-    assert ev.kind == event.EventKind.TEXT_NOTE
+def test_from_content_no_tags(keys):
+    ev = text_note_event.TextNoteEvent.from_content(keys, "Hello World!")
+    assert ev.kind == types.EventKind.TEXT_NOTE
     assert ev.tags == event_tags.EventTags([])
     assert ev.content == "Hello World!"
 
 
-def test_from_content_with_tags():
+def test_from_content_with_tags(keys):
     ev = text_note_event.TextNoteEvent.from_content(
-        "Hello World!", tags=event_tags.EventTags([["p", VALID_PUBKEY_STR]])
+        keys, "Hello World!", tags=event_tags.EventTags([["p", VALID_PUBKEY_STR]])
     )
-    assert ev.kind == event.EventKind.TEXT_NOTE
+    assert ev.kind == types.EventKind.TEXT_NOTE
     assert ev.tags == event_tags.EventTags([["p", VALID_PUBKEY_STR]])
     assert ev.content == "Hello World!"

--- a/ndk/event/text_note_event.py
+++ b/ndk/event/text_note_event.py
@@ -19,12 +19,18 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+from ndk import crypto, types
 from ndk.event import event, event_tags
 
 
-class TextNoteEvent(event.UnsignedEvent):
+class TextNoteEvent(event.SignedEvent):
     @classmethod
     def from_content(
-        cls, content: str, tags: event_tags.EventTags = event_tags.EventTags([])
+        cls,
+        keys: crypto.KeyPair,
+        content: str,
+        tags: event_tags.EventTags = event_tags.EventTags([]),
     ) -> "TextNoteEvent":
-        return cls(kind=event.EventKind.TEXT_NOTE, content=content, tags=tags)
+        return cls.build(
+            keys=keys, kind=types.EventKind.TEXT_NOTE, content=content, tags=tags
+        )

--- a/ndk/relay/event_handler.py
+++ b/ndk/relay/event_handler.py
@@ -19,6 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+from ndk import types
 from ndk.event import event, event_filter
 from ndk.relay.event_repo import event_repo
 
@@ -32,7 +33,7 @@ class EventHandler:
     async def handle_event(self, ev: event.SignedEvent):
         await self._repo.add(ev)
 
-        if ev.kind in [event.EventKind.SET_METADATA, event.EventKind.CONTACT_LIST]:
+        if ev.kind in [types.EventKind.SET_METADATA, types.EventKind.CONTACT_LIST]:
             existing_evs = await self._repo.get(
                 [event_filter.EventFilter(authors=[ev.pubkey], kinds=[ev.kind])]
             )

--- a/ndk/relay/event_repo/mysql_event_repo.py
+++ b/ndk/relay/event_repo/mysql_event_repo.py
@@ -25,7 +25,7 @@ import sqlalchemy
 from sqlalchemy.ext import asyncio as sa_asyncio
 
 from ndk import serialize, types
-from ndk.event import event, event_filter
+from ndk.event import event, event_builder, event_filter
 from ndk.relay.event_repo import event_repo
 
 logger = logging.getLogger(__name__)
@@ -269,7 +269,7 @@ class MySqlEventRepo(event_repo.EventRepo):
             result = (await conn.execute(final)).fetchall()
 
             return [
-                event.SignedEvent.from_validated_dict(
+                event_builder.from_validated_dict(
                     {
                         "id": row[0],
                         "pubkey": row[1],

--- a/ndk/relay/message_dispatcher.py
+++ b/ndk/relay/message_dispatcher.py
@@ -40,7 +40,7 @@ class MessageDispatcher:
         try:
             msg = message_factory.from_str(data)
             return await self._handle_msg(msg)
-        except exceptions.ParseError:
+        except (exceptions.ParseError, ValueError):
             text = f"Unable to parse message: {data}"
             logger.info(text, exc_info=True)
             return [create_notice(text)]

--- a/ndk/relay/message_handler.py
+++ b/ndk/relay/message_handler.py
@@ -22,7 +22,7 @@
 import logging
 
 from ndk import exceptions
-from ndk.event import event, event_filter
+from ndk.event import event_builder, event_filter
 from ndk.messages import (
     close,
     command_result,
@@ -54,7 +54,7 @@ class MessageHandler:
 
     async def handle_event_message(self, msg: event_message.Event) -> list[str]:
         try:
-            signed_ev = event.SignedEvent.from_dict(msg.event_dict)
+            signed_ev = event_builder.from_dict(msg.event_dict)
             await self._event_handler.handle_event(signed_ev)
             return [command_result.CommandResult(signed_ev.id, True, "").serialize()]
         except exceptions.ValidationError:

--- a/ndk/relay/test_event_handler.py
+++ b/ndk/relay/test_event_handler.py
@@ -22,7 +22,8 @@
 import mock
 import pytest
 
-from ndk.event import event, metadata_event
+from ndk import types
+from ndk.event import metadata_event
 from ndk.relay import event_handler
 from ndk.relay.event_repo import memory_event_repo
 
@@ -63,7 +64,7 @@ async def test_handle_contact_list_saves():
 
 
 @pytest.mark.parametrize(
-    "kind", [event.EventKind.CONTACT_LIST, event.EventKind.SET_METADATA]
+    "kind", [types.EventKind.CONTACT_LIST, types.EventKind.SET_METADATA]
 )
 async def test_handle_contact_list_deletes_old(kind):
     repo = mock.AsyncMock(wraps=memory_event_repo.MemoryEventRepo())

--- a/ndk/relay/test_message_dispatcher.py
+++ b/ndk/relay/test_message_dispatcher.py
@@ -86,9 +86,13 @@ async def test_event_missing_required_fields(md):
     assert isinstance(response_msg, notice.Notice)
 
 
-async def test_close_without_req_raises(md):
-    with pytest.raises(ValueError):
-        await md.process_message(close.Close("1").serialize())
+async def test_close_without_req_sends_notice(md):
+    response = await md.process_message(close.Close("1").serialize())
+
+    assert len(response) == 1
+    response_msg = message_factory.from_str(response[0])
+
+    assert isinstance(response_msg, notice.Notice)
 
 
 async def test_handle_request_no_match(md):

--- a/ndk/relay/test_message_handler.py
+++ b/ndk/relay/test_message_handler.py
@@ -24,7 +24,7 @@ import mock
 import pytest
 
 from ndk import exceptions
-from ndk.event import event, event_filter
+from ndk.event import event_builder, event_filter
 from ndk.messages import close, command_result, event_message, message_factory, request
 from ndk.relay import event_handler, message_handler, subscription_handler
 from ndk.relay.event_repo import memory_event_repo
@@ -56,7 +56,7 @@ async def test_event_validation_failure_returns_command_result_false(mh):
         raise exceptions.ValidationError("Failed validation")
 
     with mock.patch.object(
-        event.SignedEvent, "from_dict", lambda self, **kwargs: raise_validation_error()
+        event_builder, "from_dict", lambda self, **kwargs: raise_validation_error()
     ):
         response = await mh.handle_event_message(event_message.Event({"id": "1"}))
 
@@ -71,9 +71,7 @@ async def test_accepted_returns_command_result_true(mh):
     mocked = mock.MagicMock()
     mocked.id = "1"
 
-    with mock.patch.object(
-        event.SignedEvent, "from_dict", lambda self, **kwargs: mocked
-    ):
+    with mock.patch.object(event_builder, "from_dict", lambda self, **kwargs: mocked):
         response = await mh.handle_event_message(event_message.Event({"id": "1"}))
 
         assert len(response) == 1
@@ -87,9 +85,7 @@ async def test_accepted_calls_event_handler(mh, eh_mock):
     mocked = mock.MagicMock()
     mocked.id = "1"
 
-    with mock.patch.object(
-        event.SignedEvent, "from_dict", lambda self, **kwargs: mocked
-    ):
+    with mock.patch.object(event_builder, "from_dict", lambda self, **kwargs: mocked):
         await mh.handle_event_message(event_message.Event({"id": "1"}))
 
     eh_mock.handle_event.assert_called_with(mocked)
@@ -125,9 +121,7 @@ async def test_accepted_calls_subscription_handler(mh, sh_mock, repo):
 
     mocked = mock.AsyncMock()
     mocked.id = "1"
-    with mock.patch.object(
-        event.SignedEvent, "from_dict", lambda self, **kwargs: mocked
-    ):
+    with mock.patch.object(event_builder, "from_dict", lambda self, **kwargs: mocked):
         response = await mh.handle_event_message(event_message.Event({"id": "1"}))
 
         assert len(response) == 1

--- a/ndk/relay/test_subscription_handler.py
+++ b/ndk/relay/test_subscription_handler.py
@@ -24,8 +24,7 @@ import asyncio
 import mock
 import pytest
 
-from ndk import crypto
-from ndk.event import event, metadata_event
+from ndk.event import metadata_event
 from ndk.relay import subscription_handler
 
 
@@ -62,7 +61,7 @@ async def test_no_output_with_wrong_filter():
     assert q.empty()
 
 
-async def test_output_with_matching_filter():
+async def test_output_with_matching_filter(keys):
     q = asyncio.Queue()
     sh = subscription_handler.SubscriptionHandler(q)
 
@@ -70,14 +69,12 @@ async def test_output_with_matching_filter():
     fltr.matches_event.return_value = True
     sh.set_filters("subid", [fltr])
 
-    keys = crypto.KeyPair()
-    unsigned = metadata_event.MetadataEvent.from_metadata_parts()
-    signed = event.build_signed_event(unsigned, keys)
+    signed = metadata_event.MetadataEvent.from_metadata_parts(keys=keys)
     await sh.handle_event(signed)
     assert not q.empty()
 
 
-async def test_two_output_with_two_matching_filter():
+async def test_two_output_with_two_matching_filter(keys):
     q = asyncio.Queue()
     sh = subscription_handler.SubscriptionHandler(q)
 
@@ -86,9 +83,7 @@ async def test_two_output_with_two_matching_filter():
     sh.set_filters("subid", [fltr])
     sh.set_filters("subid2", [fltr])
 
-    keys = crypto.KeyPair()
-    unsigned = metadata_event.MetadataEvent.from_metadata_parts()
-    signed = event.build_signed_event(unsigned, keys)
+    signed = metadata_event.MetadataEvent.from_metadata_parts(keys=keys)
     await sh.handle_event(signed)
     assert q.qsize() == 2
 

--- a/ndk/repos/event_repo/event_repo.py
+++ b/ndk/repos/event_repo/event_repo.py
@@ -57,14 +57,14 @@ class EventRepo(abc.ABC):
     @abc.abstractmethod
     async def get_by_author(
         self,
-        kind: event.EventKind,
+        kind: types.EventKind,
         author: crypto.PublicKeyStr,
         limit: int = 0,
-    ) -> typing.Sequence[event.UnsignedEvent]:
+    ) -> typing.Sequence[event.SignedEvent]:
         """Retrieve Events of a given kind.
 
         Args:
-            kind (event.EventKind): The kind to match
+            kind (types.EventKind): The kind to match
             author (crypto.PublicKeyStr): The pubkey of the author of the event to match
             limit (int, optional): The maximum number of events to return. May return fewer. Defaults to 0.
 
@@ -73,12 +73,12 @@ class EventRepo(abc.ABC):
         """
 
     async def get_latest_by_author(
-        self, kind: event.EventKind, author: crypto.PublicKeyStr
-    ) -> typing.Optional[event.UnsignedEvent]:
+        self, kind: types.EventKind, author: crypto.PublicKeyStr
+    ) -> typing.Optional[event.SignedEvent]:
         """Convenience function to return the latest single event of a given kind from a specific author
 
         Args:
-            kind (event.EventKind): The kind to match
+            kind (types.EventKind): The kind to match
             author (crypto.PublicKeyStr): The pubkey of the author of the event to match
 
         Raises:

--- a/ndk/repos/event_repo/memory_event_repo.py
+++ b/ndk/repos/event_repo/memory_event_repo.py
@@ -31,7 +31,7 @@ Typical usage example::
 import typing
 
 from ndk import crypto, types
-from ndk.event import event, event_parser
+from ndk.event import event
 from ndk.repos.event_repo import event_repo
 
 
@@ -56,16 +56,16 @@ class MemoryEventRepo(event_repo.EventRepo):
 
     async def get_by_author(
         self,
-        kind: event.EventKind,
+        kind: types.EventKind,
         author: crypto.PublicKeyStr,
         limit: int = 0,
-    ) -> typing.Sequence[event.UnsignedEvent]:
+    ) -> typing.Sequence[event.SignedEvent]:
         if limit <= 0:
             limit = len(self._by_id)
 
         return sorted(
             [
-                event_parser.signed_to_unsigned(ev)
+                ev
                 for ev in self._by_id.values()
                 if ev.kind == kind and ev.pubkey == author
             ],

--- a/ndk/repos/event_repo/protocol_handler.py
+++ b/ndk/repos/event_repo/protocol_handler.py
@@ -132,7 +132,7 @@ class ProtocolHandler:
 
     async def query_events(
         self, fltrs: list[event_filter.EventFilter]
-    ) -> typing.Sequence[event.UnsignedEvent]:
+    ) -> typing.Sequence[event.SignedEvent]:
         # logger.debug("query_events(%s)", fltrs)
         sub_id = str(uuid.uuid4())
         req = request.Request(sub_id, [fltr.for_req() for fltr in fltrs])

--- a/ndk/repos/event_repo/relay_event_repo.py
+++ b/ndk/repos/event_repo/relay_event_repo.py
@@ -66,7 +66,7 @@ class RelayEventRepo(event_repo.EventRepo):
 
         return types.EventID(result.event_id)
 
-    async def get(self, ev_id: types.EventID) -> event.UnsignedEvent:
+    async def get(self, ev_id: types.EventID) -> event.SignedEvent:
         events = await self._protocol.query_events(
             [event_filter.EventFilter(ids=[ev_id])]
         )
@@ -83,10 +83,10 @@ class RelayEventRepo(event_repo.EventRepo):
 
     async def get_by_author(
         self,
-        kind: event.EventKind,
+        kind: types.EventKind,
         author: crypto.PublicKeyStr,
         limit: int = 0,
-    ) -> typing.Sequence[event.UnsignedEvent]:
+    ) -> typing.Sequence[event.SignedEvent]:
         fltr = event_filter.EventFilter(kinds=[kind], authors=[author])
 
         if limit:

--- a/ndk/repos/text_note_repo/event_backed_text_note_repo.py
+++ b/ndk/repos/text_note_repo/event_backed_text_note_repo.py
@@ -21,8 +21,8 @@
 
 import typing
 
-from ndk import crypto
-from ndk.event import event, text_note_event
+from ndk import crypto, types
+from ndk.event import text_note_event
 from ndk.repos.event_repo import event_repo
 from ndk.repos.text_note_repo import text_note_repo
 
@@ -36,9 +36,9 @@ class EventBackedTextNoteRepo(text_note_repo.TextNoteRepo):
     async def add(
         self, keys: crypto.KeyPair, content: str
     ) -> text_note_repo.TextNoteID:
-        ev = text_note_event.TextNoteEvent.from_content(content)
+        ev = text_note_event.TextNoteEvent.from_content(keys, content)
 
-        ev_id = await self._event_repo.add(event.build_signed_event(ev, keys))
+        ev_id = await self._event_repo.add(ev)
         return text_note_repo.TextNoteID(ev_id)
 
     async def get_by_uid(
@@ -49,15 +49,13 @@ class EventBackedTextNoteRepo(text_note_repo.TextNoteRepo):
         if not signed_event:
             raise ValueError(f"TextNote with uid: {uid} not found.")
 
-        return text_note_repo.TextNoteContent(
-            text_note_event.TextNoteEvent.from_signed_event(signed_event).content
-        )
+        return text_note_repo.TextNoteContent(signed_event.content)
 
     async def get_by_author(
         self, author: crypto.PublicKeyStr
     ) -> typing.Sequence[text_note_repo.TextNoteContent]:
         unsigned_events = await self._event_repo.get_by_author(
-            event.EventKind.TEXT_NOTE, author
+            types.EventKind.TEXT_NOTE, author
         )
 
         return [text_note_repo.TextNoteContent(ev.content) for ev in unsigned_events]

--- a/ndk/test_types.py
+++ b/ndk/test_types.py
@@ -19,30 +19,21 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import typing
+import pytest
 
-from ndk.event import (
-    contact_list_event,
-    event,
-    metadata_event,
-    reaction_event,
-    recommend_server_event,
-    repost_event,
-    text_note_event,
-)
-
-LOOKUP: dict[event.EventKind, typing.Type[event.UnsignedEvent]] = {
-    event.EventKind.SET_METADATA: metadata_event.MetadataEvent,
-    event.EventKind.RECOMMEND_SERVER: recommend_server_event.RecommendServerEvent,
-    event.EventKind.TEXT_NOTE: text_note_event.TextNoteEvent,
-    event.EventKind.CONTACT_LIST: contact_list_event.ContactListEvent,
-    event.EventKind.REPOST: repost_event.RepostEvent,
-    event.EventKind.REACTION: reaction_event.ReactionEvent,
-}
+from ndk import types
 
 
-def signed_to_unsigned(signed_event: event.SignedEvent) -> event.UnsignedEvent:
-    if signed_event.kind not in LOOKUP:
-        raise ValueError(f"Attempting to parse an unknown event {signed_event}")
+def test_event_id_bad_size():
+    with pytest.raises(ValueError):
+        types.EventID("a" * 63)
 
-    return LOOKUP[signed_event.kind].from_signed_event(signed_event)
+
+def test_event_id_non_hex():
+    with pytest.raises(ValueError):
+        types.EventID("$" * 64)
+
+
+def test_event_id_non_str():
+    with pytest.raises(ValueError):
+        types.EventID([])  # type: ignore

--- a/ndk/types.py
+++ b/ndk/types.py
@@ -19,6 +19,8 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import enum
+
 
 class FixedLengthHexStr(str):
     _length: int
@@ -44,3 +46,13 @@ class FixedLengthHexStr(str):
 
 class EventID(FixedLengthHexStr):
     _length: int = 64
+
+
+class EventKind(enum.IntEnum):
+    INVALID = -1
+    SET_METADATA = 0
+    TEXT_NOTE = 1
+    RECOMMEND_SERVER = 2
+    CONTACT_LIST = 3
+    REPOST = 6
+    REACTION = 7

--- a/relay/test_server.py
+++ b/relay/test_server.py
@@ -22,7 +22,7 @@
 import asyncio
 
 from ndk import crypto
-from ndk.event import event, metadata_event
+from ndk.event import metadata_event
 from ndk.relay import (
     event_handler,
     message_dispatcher,
@@ -45,8 +45,7 @@ async def test_init():
     handler_task = asyncio.create_task(server.connection_handler(rq, wq, mb))
 
     keys = crypto.KeyPair()
-    ev = metadata_event.MetadataEvent.from_metadata_parts()
-    signed = event.build_signed_event(ev, keys)
+    signed = metadata_event.MetadataEvent.from_metadata_parts(keys)
 
     ph = protocol_handler.ProtocolHandler(wq, rq)
     read_loop_task = asyncio.create_task(ph.start_read_loop())

--- a/spec_tests/test_nip_25_reaction_events.py
+++ b/spec_tests/test_nip_25_reaction_events.py
@@ -25,8 +25,7 @@ import asyncio
 
 import pytest
 
-from ndk import crypto
-from ndk.event import event, reaction_event, text_note_event
+from ndk.event import reaction_event, text_note_event
 from spec_tests import utils
 
 
@@ -45,16 +44,9 @@ def ctx(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.fixture
-def keys():
-    return crypto.KeyPair()
-
-
 @pytest.fixture()
-def text_note(request_queue, response_queue):
-    keys1 = crypto.KeyPair()
-    unsigned_event = text_note_event.TextNoteEvent.from_content("Hello World!")
-    signed_event = event.build_signed_event(unsigned_event, keys1)
+def text_note(keys, request_queue, response_queue):
+    signed_event = text_note_event.TextNoteEvent.from_content(keys, "Hello World!")
 
     asyncio.get_event_loop().run_until_complete(
         utils.send_and_expect_command_result(
@@ -66,9 +58,7 @@ def text_note(request_queue, response_queue):
 
 @pytest.fixture
 def signed_reaction_event(keys, text_note):
-    unsigned_event = reaction_event.ReactionEvent.from_text_note_event(text_note)
-    signed_event = event.build_signed_event(unsigned_event, keys)
-    return signed_event
+    return reaction_event.ReactionEvent.from_text_note_event(keys, text_note)
 
 
 @pytest.mark.usefixtures("ctx")

--- a/spec_tests/utils.py
+++ b/spec_tests/utils.py
@@ -23,7 +23,13 @@
 
 import typing
 
-from ndk.event import event, event_parser, reaction_event, repost_event, text_note_event
+from ndk.event import (
+    event,
+    event_builder,
+    reaction_event,
+    repost_event,
+    text_note_event,
+)
 from ndk.messages import (
     close,
     command_result,
@@ -68,12 +74,11 @@ async def expect_successful_command_result(response_queue):
 
 
 async def expect_relay_event_of_type(
-    event_type: typing.Type[event.UnsignedEvent], response_queue
+    event_type: typing.Type[event.SignedEvent], response_queue
 ):
     msg = await expect_relay_event(response_queue)
-    signed = event.SignedEvent.from_dict(msg.event_dict)
-    unsigned = event_parser.signed_to_unsigned(signed)
-    assert isinstance(unsigned, event_type)
+    signed = event_builder.from_dict(msg.event_dict)
+    assert isinstance(signed, event_type)
     return signed
 
 


### PR DESCRIPTION
Now that more of the project is fleshed out, the difference between signed and unsigned event types isn't used and causes additional complexity. Remove it.

- EventKind moved to ndk.types
- s/event_parser/event_builder/g