### PR TITLE
[feat] Implement NIP-42 AUTH

### DIFF
--- a/ndk/event/auth_event.py
+++ b/ndk/event/auth_event.py
@@ -1,0 +1,68 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import dataclasses
+import time
+
+from ndk import crypto, types
+from ndk.event import event, event_tags
+
+
+@dataclasses.dataclass
+class AuthEvent(event.Event):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def validate(self):
+        if self.kind != types.EventKind.AUTH:
+            raise ValueError(f"AuthEvent must have kind {types.EventKind.AUTH}")
+
+        now = int(time.time())
+        if abs(now - self.created_at) > 600:
+            raise ValueError("AuthEvent must be created within 10 minutes of now")
+
+        relay_tag = self.tags.get("relay")
+        if relay_tag == []:
+            raise ValueError("AuthEvent must have a relay tag")
+
+        challenge_tag = self.tags.get("challenge")
+        if challenge_tag == []:
+            raise ValueError("AuthEvent must have a challenge tag")
+
+        return super().validate()
+
+    @classmethod
+    def from_parts(
+        cls,
+        keys: crypto.KeyPair,
+        relay_url: str,
+        relay_challenge: str,
+    ):
+        return cls.build(
+            keys=keys,
+            kind=types.EventKind.AUTH,
+            tags=event_tags.EventTags(
+                [
+                    event_tags.AuthRelayTag.from_relay_url(relay_url),
+                    event_tags.AuthChallengeTag.from_challenge(relay_challenge),
+                ]
+            ),
+        )

--- a/ndk/event/event.py
+++ b/ndk/event/event.py
@@ -78,10 +78,12 @@ class Event:
         cls,
         keys: crypto.KeyPair,
         kind: int,
+        created_at: typing.Optional[int] = None,
         tags: typing.Optional[event_tags.EventTags] = None,
         content: typing.Optional[str] = None,
     ):
-        created_at = int(time.time())
+        if created_at is None:
+            created_at = int(time.time())
         if tags is None:
             tags = event_tags.EventTags()
         if content is None:

--- a/ndk/event/event_builder.py
+++ b/ndk/event/event_builder.py
@@ -24,6 +24,7 @@ import typing
 
 from ndk import crypto, types
 from ndk.event import (
+    auth_event,
     contact_list_event,
     event,
     event_tags,
@@ -43,6 +44,7 @@ LOOKUP: dict[int, typing.Type[event.Event]] = {
     types.EventKind.CONTACT_LIST: contact_list_event.ContactListEvent,
     types.EventKind.REPOST: repost_event.RepostEvent,
     types.EventKind.REACTION: reaction_event.ReactionEvent,
+    types.EventKind.AUTH: auth_event.AuthEvent,
 }
 
 REQUIRED_FIELDS = set(["id", "pubkey", "created_at", "kind", "tags", "content", "sig"])

--- a/ndk/event/event_tags.py
+++ b/ndk/event/event_tags.py
@@ -95,6 +95,46 @@ class EventIdTag(EventTag):
         return cls(["e", event_id])
 
 
+class AuthRelayTag(EventTag):
+    def __init__(self, value: list[str]):
+        if len(value) != 2:
+            raise ValueError(
+                f"{self.__class__.__name__} must have 2 items, not {value}"
+            )
+
+        if value[0] != "relay":
+            raise ValueError(
+                f"{self.__class__.__name__} must start with 'relay', not {value}"
+            )
+
+        validate_relay_url(value[1])
+
+        super().__init__(value)
+
+    @classmethod
+    def from_relay_url(cls, relay_url: str):
+        return cls(["relay", relay_url])
+
+
+class AuthChallengeTag(EventTag):
+    def __init__(self, value: list[str]):
+        if len(value) != 2:
+            raise ValueError(
+                f"{self.__class__.__name__} must have 2 items, not {value}"
+            )
+
+        if value[0] != "challenge":
+            raise ValueError(
+                f"{self.__class__.__name__} must start with 'relay', not {value}"
+            )
+
+        super().__init__(value)
+
+    @classmethod
+    def from_challenge(cls, challenge: str):
+        return cls(["challenge", challenge])
+
+
 class UnknownEventTag(EventTag):
     pass
 
@@ -130,6 +170,10 @@ class EventTags(list):
             return PublicKeyTag(tag)
         elif tag[0] == "e":
             return EventIdTag(tag)
+        elif tag[0] == "relay":
+            return AuthRelayTag(tag)
+        elif tag[0] == "challenge":
+            return AuthChallengeTag(tag)
         else:
             return UnknownEventTag(tag)
 

--- a/ndk/event/test_auth_event.py
+++ b/ndk/event/test_auth_event.py
@@ -1,0 +1,87 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+
+import mock
+import pytest
+
+from ndk import types
+from ndk.event import auth_event, event_builder, event_tags
+
+VALID_RELAY_URL = "wss://nostr.com.se"
+VALID_TAGS = event_tags.EventTags([["relay", VALID_RELAY_URL], ["challenge", "foobar"]])
+
+
+def test_from_parts(keys):
+    ev = auth_event.AuthEvent.from_parts(keys, VALID_RELAY_URL, "foobar")
+    assert ev.kind == types.EventKind.AUTH
+    assert ev.tags == VALID_TAGS
+    assert ev.content == ""
+
+
+def test_init_bad_kind(keys):
+    with pytest.raises(ValueError):
+        auth_event.AuthEvent.build(keys, types.EventKind.REACTION, tags=VALID_TAGS)
+
+
+def test_init_too_old(keys):
+    now = int(time.time())
+    with mock.patch("time.time", return_value=now):
+        with pytest.raises(ValueError):
+            auth_event.AuthEvent.build(
+                keys, types.EventKind.AUTH, created_at=now + 601, tags=VALID_TAGS
+            )
+
+
+def test_init_too_new(keys):
+    now = int(time.time())
+    with mock.patch("time.time", return_value=now):
+        with pytest.raises(ValueError):
+            auth_event.AuthEvent.build(
+                keys, types.EventKind.AUTH, created_at=now - 601, tags=VALID_TAGS
+            )
+
+
+def test_init_bad_tags(keys):
+    with pytest.raises(ValueError):
+        auth_event.AuthEvent.build(
+            keys,
+            types.EventKind.AUTH,
+            tags=event_tags.EventTags([["relay", VALID_RELAY_URL]]),
+        )
+
+
+def test_init_bad_tags2(keys):
+    with pytest.raises(ValueError):
+        auth_event.AuthEvent.build(
+            keys,
+            types.EventKind.AUTH,
+            tags=event_tags.EventTags([["challenge", "foobar"]]),
+        )
+
+
+def test_event_builder(keys):
+    ev = auth_event.AuthEvent.from_parts(keys, VALID_RELAY_URL, "foobar")
+
+    ev2 = event_builder.from_dict(ev.__dict__)
+
+    assert ev == ev2

--- a/ndk/event/test_event_tags.py
+++ b/ndk/event/test_event_tags.py
@@ -27,6 +27,7 @@ from ndk.event import event_tags
 VALID_PUBKEY_STR = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
 VALID_EVENT_ID_STR = VALID_PUBKEY_STR
 VALID_RELAY_STR = "wss://nostr.com.se"
+VALID_CHALLENGE = "1234"
 
 
 def test_init_event_tag_bad_type_fails():
@@ -132,6 +133,54 @@ def test_init_e_tag_from_pubkey_and_relay():
 def test_init_e_tag_from_pubkey_and_malformed_relay():
     with pytest.raises(ValueError):
         event_tags.EventIdTag.from_event_id(types.EventID(VALID_EVENT_ID_STR), "blergh")
+
+
+def test_relay_tag_bad_length_4():
+    with pytest.raises(ValueError):
+        event_tags.AuthRelayTag(["relay", VALID_RELAY_STR, "b", "g"])
+
+
+def test_relay_tag_bad_length_1():
+    with pytest.raises(ValueError):
+        event_tags.AuthRelayTag(["relay"])
+
+
+def test_relay_tag_bad_identifier():
+    with pytest.raises(ValueError):
+        event_tags.AuthRelayTag(["challenge", VALID_RELAY_STR])
+
+
+def test_relay_tag_correct():
+    event_tags.AuthRelayTag(["relay", VALID_RELAY_STR])
+
+
+def test_relay_tag_from_relay_url():
+    et = event_tags.AuthRelayTag.from_relay_url(VALID_RELAY_STR)
+    assert str(et) == f"['relay', '{VALID_RELAY_STR}']"
+
+
+def test_challenge_tag_bad_length_4():
+    with pytest.raises(ValueError):
+        event_tags.AuthChallengeTag(["challenge", VALID_CHALLENGE, "b", "g"])
+
+
+def test_challenge_tag_bad_length_1():
+    with pytest.raises(ValueError):
+        event_tags.AuthChallengeTag(["challenge"])
+
+
+def test_challenge_tag_bad_identifier():
+    with pytest.raises(ValueError):
+        event_tags.AuthChallengeTag(["relay", VALID_CHALLENGE])
+
+
+def test_challenge_tag_correct():
+    event_tags.AuthChallengeTag(["challenge", VALID_CHALLENGE])
+
+
+def test_challenge_tag_from_challenge():
+    et = event_tags.AuthChallengeTag.from_challenge(VALID_CHALLENGE)
+    assert str(et) == f"['challenge', '{VALID_CHALLENGE}']"
 
 
 def test_unknown_event_tag():

--- a/ndk/messages/message_factory.py
+++ b/ndk/messages/message_factory.py
@@ -24,6 +24,7 @@ import typing
 
 from ndk import exceptions, serialize
 from ndk.messages import (
+    auth,
     close,
     command_result,
     eose,
@@ -60,6 +61,7 @@ def from_str(data: str) -> message.Message:
         "EVENT": relay_event.RelayEvent,
         "REQ": request.Request,
         "CLOSE": close.Close,
+        "AUTH": auth.Auth,
     }
 
     if hdr not in factories:

--- a/ndk/relay/event_handler.py
+++ b/ndk/relay/event_handler.py
@@ -20,18 +20,23 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-from ndk.event import event, event_filter
-from ndk.relay import event_notifier
+from ndk.event import auth_event, event, event_filter
+from ndk.relay import auth_handler, event_notifier
 from ndk.relay.event_repo import event_repo
 
 
 class EventHandler:
+    _auth_handler: auth_handler.AuthHandler
     _received_event_notifier: event_notifier.EventNotifier
     _repo: event_repo.EventRepo
 
     def __init__(
-        self, repo: event_repo.EventRepo, notifier: event_notifier.EventNotifier
+        self,
+        auth: auth_handler.AuthHandler,
+        repo: event_repo.EventRepo,
+        notifier: event_notifier.EventNotifier,
     ):
+        self._auth_handler = auth
         self._received_event_notifier = notifier
         self._repo = repo
 
@@ -48,6 +53,9 @@ class EventHandler:
 
         if isinstance(ev, event.BroadcastEvent):
             await self._received_event_notifier.handle_event(ev)
+
+        if isinstance(ev, auth_event.AuthEvent):
+            self._auth_handler.handle_auth_event(ev)
 
     def register_received_cb(
         self, cb: event_notifier.EventNotifierCb

--- a/ndk/relay/test_auth_handler.py
+++ b/ndk/relay/test_auth_handler.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# pylint: disable=redefined-outer-name, unused-argument, protected-access
+
+import pytest
+
+from ndk import serialize
+from ndk.event import auth_event
+from ndk.relay import auth_handler
+
+VALID_RELAY_URL = "wss://relay.example.com"
+
+
+def test_default_is_authenticated():
+    h = auth_handler.AuthHandler(VALID_RELAY_URL)
+    assert not h.is_authenticated()
+
+
+def test_build_auth_message():
+    h = auth_handler.AuthHandler(VALID_RELAY_URL)
+    m = serialize.deserialize(h.build_auth_message())
+    assert m[0] == "AUTH"
+    assert isinstance(m[1], str)
+
+
+def test_handle_auth_event_wrong_relay(keys):
+    h = auth_handler.AuthHandler(VALID_RELAY_URL)
+    with pytest.raises(ValueError, match="expected relay"):
+        h.handle_auth_event(
+            auth_event.AuthEvent.from_parts(keys, "wss://wrong.example.com", "1")
+        )
+    assert not h.is_authenticated()
+
+
+def test_handle_auth_event_wrong_challenge(keys):
+    h = auth_handler.AuthHandler(VALID_RELAY_URL)
+    with pytest.raises(ValueError, match="expected challenge"):
+        h.handle_auth_event(auth_event.AuthEvent.from_parts(keys, VALID_RELAY_URL, "1"))
+    assert not h.is_authenticated()
+
+
+def test_handle_auth_event(keys):
+    h = auth_handler.AuthHandler(VALID_RELAY_URL)
+    h.handle_auth_event(
+        auth_event.AuthEvent.from_parts(keys, VALID_RELAY_URL, h._challenge)
+    )
+    assert h.is_authenticated()

--- a/ndk/relay/test_message_dispatcher.py
+++ b/ndk/relay/test_message_dispatcher.py
@@ -27,6 +27,7 @@ import pytest
 from ndk import serialize
 from ndk.messages import close, eose, event_message, message_factory, notice, request
 from ndk.relay import (
+    auth_handler,
     event_handler,
     event_notifier,
     message_dispatcher,
@@ -38,9 +39,10 @@ from ndk.relay.event_repo import memory_event_repo
 
 @pytest.fixture
 def md():
+    auth = auth_handler.AuthHandler("wss://unittests")
     sh = subscription_handler.SubscriptionHandler(asyncio.Queue())
     repo = memory_event_repo.MemoryEventRepo()
-    eh = event_handler.EventHandler(repo, event_notifier.EventNotifier())
+    eh = event_handler.EventHandler(auth, repo, event_notifier.EventNotifier())
     ev_handler = message_handler.MessageHandler(repo, sh, eh)
     return message_dispatcher.MessageDispatcher(ev_handler)
 

--- a/ndk/relay/test_message_handler.py
+++ b/ndk/relay/test_message_handler.py
@@ -27,6 +27,7 @@ from ndk import exceptions
 from ndk.event import event, event_builder, event_filter
 from ndk.messages import close, command_result, event_message, message_factory, request
 from ndk.relay import (
+    auth_handler,
     event_handler,
     event_notifier,
     message_handler,
@@ -47,8 +48,11 @@ def sh_mock():
 
 @pytest.fixture
 def eh_mock(repo):
+    auth = auth_handler.AuthHandler("wss://unittests")
     return mock.AsyncMock(
-        wraps=event_handler.EventHandler(repo, notifier=event_notifier.EventNotifier())
+        wraps=event_handler.EventHandler(
+            auth, repo, notifier=event_notifier.EventNotifier()
+        )
     )
 
 


### PR DESCRIPTION
The server will now send a challenge as the first message on the response queue.

Each connection has an internal authenticated state that is updated when a valid response is received. Valid for the entire connection time.

Tests don't authenticate for now. No client support for auth.

Resolves #95 