### PR TITLE
[feat] Implement NIP-33 and NIP-12 as a pre-req

### DIFF
--- a/ndk/event/event_builder.py
+++ b/ndk/event/event_builder.py
@@ -23,12 +23,9 @@ import logging
 import typing
 
 from ndk import crypto, types
+from ndk.event import auth_event, contact_list_event, event, event_tags, metadata_event
+from ndk.event import parameterized_replaceable_event as pre
 from ndk.event import (
-    auth_event,
-    contact_list_event,
-    event,
-    event_tags,
-    metadata_event,
     reaction_event,
     recommend_server_event,
     repost_event,
@@ -69,6 +66,9 @@ def from_dict(fields: dict, skip_validate=False):
     elif 20000 <= kind < 30000:
         builder = event.EphemeralEvent
         logger.warning("Handling unspecified EphemeralEvent: %s", fields)
+    elif 30000 <= kind < 40000:
+        builder = pre.ParameterizedReplaceableEvent
+        logger.warning("Handling unspecified ParameterizedReplaceableEvent: %s", fields)
     else:
         raise ValueError(f"Invalid event kind {kind}")
 

--- a/ndk/event/parameterized_replaceable_event.py
+++ b/ndk/event/parameterized_replaceable_event.py
@@ -1,0 +1,56 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+# https://github.com/nostr-protocol/nips/blob/master/33.md
+
+import dataclasses
+import typing
+
+from ndk.event import event
+
+
+@dataclasses.dataclass
+class ParameterizedReplaceableEvent(
+    event.Event,
+    event.PersistentEvent,
+    event.SingletonEvent,
+    event.BroadcastEvent,
+):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def validate(self):
+        if not 30000 <= self.kind < 40000:
+            raise ValueError(
+                "ParameterizedReplaceableEvent must be in range [20000-30000)"
+            )
+
+        return super().validate()
+
+    def get_normalized_d_tag_value(self) -> typing.Optional[str]:
+        """Implement NIP-33 behavior to normalize d tags across variants"""
+        tags = self.tags.get("d")
+        if len(tags) == 0:
+            return None
+
+        if tags[0][1] == "":
+            return None
+
+        return tags[0][1]

--- a/ndk/event/test_event_builder.py
+++ b/ndk/event/test_event_builder.py
@@ -24,6 +24,7 @@ import pytest
 
 from ndk import crypto, exceptions, types
 from ndk.event import event, event_builder, metadata_event
+from ndk.event import parameterized_replaceable_event as pre
 
 
 @pytest.fixture
@@ -148,3 +149,14 @@ def test_ephemeral_event():
 
     reconstructed_event = event_builder.from_dict(ev.__dict__)
     assert isinstance(reconstructed_event, event.EphemeralEvent)
+
+
+def test_parameterized_replaceable_event():
+    ev = event.Event.build(
+        keys=crypto.KeyPair(),
+        kind=30000,
+        content="special state",
+    )
+
+    reconstructed_event = event_builder.from_dict(ev.__dict__)
+    assert isinstance(reconstructed_event, pre.ParameterizedReplaceableEvent)

--- a/ndk/event/test_parameterized_replaceable_event.py
+++ b/ndk/event/test_parameterized_replaceable_event.py
@@ -1,0 +1,52 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import pytest
+
+from ndk import types
+from ndk.event import event_tags
+from ndk.event import parameterized_replaceable_event as pre
+
+
+def test_init_bad_kind(keys):
+    with pytest.raises(
+        ValueError, match="ParameterizedReplaceableEvent must be in range"
+    ):
+        pre.ParameterizedReplaceableEvent.build(keys, types.EventKind.REACTION)
+
+
+def test_normalized_d_tag_no_tags(keys):
+    ev = pre.ParameterizedReplaceableEvent.build(keys, kind=30000)
+    assert ev.get_normalized_d_tag_value() is None
+
+
+def test_normalized_d_tag_multiple_d_tags(keys):
+    ev = pre.ParameterizedReplaceableEvent.build(
+        keys, kind=30000, tags=event_tags.EventTags([["d", "foo"], ["d", "bar"]])
+    )
+    assert ev.get_normalized_d_tag_value() == "foo"
+
+
+def test_normalized_d_tag_long_d_tag(keys):
+    ev = pre.ParameterizedReplaceableEvent.build(
+        keys, kind=30000, tags=event_tags.EventTags([["d", "foo", "bar"]])
+    )
+    assert ev.get_normalized_d_tag_value() == "foo"

--- a/ndk/relay/event_repo/mysql_event_repo.py
+++ b/ndk/relay/event_repo/mysql_event_repo.py
@@ -238,11 +238,9 @@ class MySqlEventRepo(event_repo.EventRepo):
             if f.kinds:
                 conditions.append(EVENTS_TABLE.c.kind.in_(f.kinds))
 
-            if f.e_tags:
-                conditions.append(self.tag_query_from("e", f.e_tags))
-
-            if f.p_tags:
-                conditions.append(self.tag_query_from("p", f.p_tags))
+            if f.generic_tags:
+                for k, v in f.generic_tags.items():
+                    conditions.append(self.tag_query_from(k, v))
 
             if f.since:
                 conditions.append(EVENTS_TABLE.c.created_at > f.since)  # type: ignore[arg-type]

--- a/ndk/relay/event_repo/test_event_repo.py
+++ b/ndk/relay/event_repo/test_event_repo.py
@@ -147,7 +147,11 @@ async def test_get_no_matches_by_etag(repo, metadata_ev, keys):
     _ = await repo.add(metadata_ev)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], e_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"e": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 0
@@ -168,7 +172,11 @@ async def test_matches_by_etag(repo, keys):
     _ = await repo.add(event)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], e_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"e": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 1
@@ -181,7 +189,11 @@ async def test_matches_by_etag_duplicated(repo, keys):
     _ = await repo.add(event)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], e_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"e": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 1
@@ -194,10 +206,18 @@ async def test_matches_by_etag_event_has_multiple_tags(repo, keys):
     _ = await repo.add(event)
 
     items1 = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], e_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"e": [keys.public]}
+            )
+        ]
     )
     items2 = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], p_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"p": [keys.public]}
+            )
+        ]
     )
 
     assert len(items1) == 1
@@ -212,7 +232,11 @@ async def test_get_no_matches_by_ptag(repo, keys):
     _ = await repo.add(event)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], p_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"p": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 0
@@ -224,7 +248,11 @@ async def test_matches_by_ptag(repo, keys):
     _ = await repo.add(event)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], p_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"p": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 1
@@ -237,7 +265,11 @@ async def test_matches_by_ptag_with_relay(repo, keys):
     _ = await repo.add(event)
 
     items = await repo.get(
-        [event_filter.EventFilter(authors=[keys.public], p_tags=[keys.public])]
+        [
+            event_filter.EventFilter(
+                authors=[keys.public], generic_tags={"p": [keys.public]}
+            )
+        ]
     )
 
     assert len(items) == 1
@@ -255,7 +287,7 @@ async def test_matches_by_ptags(repo, keys):
     items = await repo.get(
         [
             event_filter.EventFilter(
-                authors=[keys.public], p_tags=[keys.public, keys2.public]
+                authors=[keys.public], generic_tags={"p": [keys.public, keys2.public]}
             )
         ]
     )
@@ -279,6 +311,20 @@ async def test_matches_multiple_filters_or(repo, keys):
     )
 
     assert len(items) == 2
+
+
+async def test_multiple_filters_match_same_event_returns_one(repo, keys):
+    event = build_text_note(keys)
+    _ = await repo.add(event)
+
+    items = await repo.get(
+        [
+            event_filter.EventFilter(authors=[keys.public]),
+            event_filter.EventFilter(authors=[keys.public]),
+        ]
+    )
+
+    assert len(items) == 1
 
 
 async def test_delete_with_no_entry_raises(repo):

--- a/spec_tests/test_nip_01_req_filters.py
+++ b/spec_tests/test_nip_01_req_filters.py
@@ -348,6 +348,26 @@ async def test_text_note_find_by_tag_etag(request_queue, response_queue, keys, e
 
 
 @pytest.mark.usefixtures("ctx")
+async def test_text_note_find_by_other_generic_tag(
+    request_queue, response_queue, keys, event
+):
+    cmd_result = await utils.send_and_expect_command_result(
+        event, request_queue, response_queue
+    )
+
+    event2 = build_with_tags(keys, tags=[["d", cmd_result.event_id]])
+
+    await utils.send_and_expect_command_result(event2, request_queue, response_queue)
+
+    fltr = {"authors": [event.pubkey], "#d": [event.id]}
+
+    await utils.send_req_with_filter("1", [fltr], request_queue)
+    relay_event = await utils.expect_text_note_event(response_queue)
+    assert relay_event == event2
+    await utils.expect_eose(response_queue)
+
+
+@pytest.mark.usefixtures("ctx")
 async def test_text_note_find_by_tag_etag_and_ptag(
     request_queue, response_queue, keys, event
 ):

--- a/spec_tests/test_nip_33_parameterized_replaceable_events.py
+++ b/spec_tests/test_nip_33_parameterized_replaceable_events.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# pylint: disable=redefined-outer-name, unused-argument
+
+import pytest
+
+from ndk import crypto
+from ndk.event import event
+from ndk.event import parameterized_replaceable_event as pre
+from spec_tests import utils
+
+
+@pytest.fixture
+def local(local_relay):
+    yield
+
+
+@pytest.fixture
+def remote(remote_relay):
+    yield
+
+
+@pytest.fixture(params=["local", "remote"])
+def ctx(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def keys():
+    return crypto.KeyPair()
+
+
+@pytest.fixture
+def ev(keys):
+    return event.EphemeralEvent.build(keys, kind=20000)
+
+
+@pytest.mark.usefixtures("ctx")
+async def test_paramterized_replaceable_event_no_tag(
+    keys, request_queue, response_queue
+):
+    ev = pre.ParameterizedReplaceableEvent.build(keys, kind=30000, created_at=1)
+    await utils.send_and_expect_command_result(ev, request_queue, response_queue)
+
+    replacement = pre.ParameterizedReplaceableEvent.build(
+        keys, kind=30000, content="foo", created_at=2
+    )
+    await utils.send_and_expect_command_result(
+        replacement, request_queue, response_queue
+    )
+
+    fltr = {"authors": [keys.public], "kinds": [30000]}
+
+    await utils.send_req_with_filter("1", [fltr], request_queue)
+    stored_ev = await utils.expect_relay_event_of_type(
+        pre.ParameterizedReplaceableEvent, response_queue
+    )
+    assert stored_ev == replacement
+    await utils.expect_eose(response_queue)


### PR DESCRIPTION
In order to handle d tag replacements, generic query tag queries were needed.

- fixed a buy in the in-memory event repo that was returning duplicate events if multiple filters were specified that returned the same event

Resolves #100 
Resolves #114 