### PR TITLE
[bugfix] Fix compatibility with coracle

### DIFF
--- a/ndk/event/event_filter.py
+++ b/ndk/event/event_filter.py
@@ -67,14 +67,23 @@ class EventFilter:
         if self.__dict__[field_name] is not None and not self.__dict__[field_name]:
             self.__dict__[field_name] = None
 
+    def remove_none(self, field_name):
+        self.check_value(field_name, list)
+        self.__dict__[field_name] = [
+            i for i in self.__dict__[field_name] if i is not None
+        ]
+
     def __post_init__(self):
         if self.ids is not None:
+            self.remove_none("ids")
             self.check_list("ids", str)
             self.set_falsy_to_none("ids")
         if self.authors is not None:
+            self.remove_none("authors")
             self.check_list("authors", str)
             self.set_falsy_to_none("authors")
         if self.kinds is not None:
+            self.remove_none("kinds")
             self.check_list("kinds", int)
             self.set_falsy_to_none("kinds")
         if self.generic_tags is not None:

--- a/ndk/test_serialize.py
+++ b/ndk/test_serialize.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Julian Knutsen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the “Software”), to deal in
+# the Software without restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from ndk import serialize
+
+
+def test_null():
+    result = serialize.deserialize('{"ids": [null]}')
+    assert result["ids"] == [None]


### PR DESCRIPTION
Sometimes, null is included as an item in the ids list, but the validation asserted that all entries were strings.